### PR TITLE
docs(part-12): fix 'Th terminology' -> 'The terminology' in functional programming page

### DIFF
--- a/data/part-12/3-functional-programming.md
+++ b/data/part-12/3-functional-programming.md
@@ -23,7 +23,7 @@ As mentioned above, functional programming is a programming paradigm, or a style
 * procedural programming, where the program is grouped into procedures or sub-programs
 * object-oriented programming, where the program and its state is stored in objects defined in classes.
 
-There are differing opinions on the divisions between the different paradigms; for example, some maintain that imperative and procedural programming mean the same thing, while others place imperative programming as an umbrella term which covers both procedural and object-oriented programming. Th terminology and divisions are not that important, and neither is strictly sticking to one or the other paradigm, but it is important to understand that such different approaches exist, as they affect the choices programmers make.
+There are differing opinions on the divisions between the different paradigms; for example, some maintain that imperative and procedural programming mean the same thing, while others place imperative programming as an umbrella term which covers both procedural and object-oriented programming. The terminology and divisions are not that important, and neither is strictly sticking to one or the other paradigm, but it is important to understand that such different approaches exist, as they affect the choices programmers make.
 
 Many programming languages are designed with one or the other programming paradigm in mind, but Python is a rather versatile programming language, and allows for following several different programming paradigms, even within a single program. This lets us choose the most efficient and clear method for solving each problem.
 


### PR DESCRIPTION
## Summary

\`data/part-12/3-functional-programming.md\` line 26 had 'Th terminology and divisions…' — missing the 'e' in 'The'. Fixed.

Closes #16

## Testing

Docs-only change.