### PR TITLE
Fix malformed lecture table HTML

### DIFF
--- a/data/index.md
+++ b/data/index.md
@@ -49,7 +49,7 @@ The next lecture in the course will take place in autumn 2026. Lecture recording
     </tr>
     <tr>
       <td>Part 3 (2025)</td>
-      <td><a href="https://youtu.be/kzGJLq6qmlc">Recording 18.09.2025</a></td>>
+      <td><a href="https://youtu.be/kzGJLq6qmlc">Recording 18.09.2025</a></td>
     </tr>
     <tr>
       <td>Part 4 (2025)</td>


### PR DESCRIPTION
A typo in lectures index HTML table in [data/index.md](https://github.com/rage/programming-26/blob/b5c5c96424efdec9c02fd040e9a81eeb8e23ff19/data/index.md) file caused to render an extra `>` symbol in the [published content](https://programming-26.mooc.fi/).

<img width="807" height="743" alt="image" src="https://github.com/user-attachments/assets/9c11b754-cdf7-4b5e-aa6d-215143241690" />

**Edit (09/26):** I've modified the original commit to conform to the latest updates in `main`.