### PR TITLE
Remove extra parentheses in part 4 lists code snippets

### DIFF
--- a/data/part-4/3-lists.md
+++ b/data/part-4/3-lists.md
@@ -652,7 +652,7 @@ Please write a function named `mean`, which takes a list of integers as an argum
 
 ```python
 my_list = [1, 2, 3, 4, 5]
-result = mean(my_list))
+result = mean(my_list)
 print("mean value is", result)
 ```
 

--- a/data/part-4/3-lists.md
+++ b/data/part-4/3-lists.md
@@ -389,7 +389,7 @@ Notice how the method modifies the list itself. Sometimes we don't want to chang
 
 ```python
 my_list = [2,5,1,2,4]
-print(sorted(my_list)))
+print(sorted(my_list))
 ```
 
 <sample-output>
@@ -671,7 +671,7 @@ Please write a function named  `range_of_list`, which takes a list of integers a
 
 ```python
 my_list = [1, 2, 3, 4, 5]
-result = range_of_list(my_list))
+result = range_of_list(my_list)
 print("The range of the list is", result)
 ```
 


### PR DESCRIPTION
This update removes extra parens found in code samples such as

```py
print(sorted(my_list)))
```

and similar in the [Part 4 Lists](https://programming-26.mooc.fi/part-4/3-lists) course page.