### PR TITLE
Localize sidebar menu labels

### DIFF
--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -3,6 +3,7 @@ import styled from "styled-components"
 import { graphql, StaticQuery } from "gatsby"
 import { Button } from "@material-ui/core"
 import CourseSettings from "../../course-settings"
+import { withTranslation } from "react-i18next"
 
 import Logo from "./Logo"
 import TreeView from "./TreeView"
@@ -177,12 +178,12 @@ const Sidebar = (props) => {
           {props.mobileMenuOpen ? (
             <span>
               <StyledIcon icon={faTimes} />
-              Sulje valikko
+              {props.t("closeMenu")}
             </span>
           ) : (
             <span>
               <StyledIcon icon={faBars} />
-              Avaa valikko
+              {props.t("openMenu")}
             </span>
           )}
         </Button>
@@ -233,4 +234,6 @@ const SidebarWithData = (props) => (
   />
 )
 
-export default withSimpleErrorBoundary(SidebarWithData)
+export default withTranslation("common")(
+  withSimpleErrorBoundary(SidebarWithData),
+)

--- a/src/locales/common/en.json
+++ b/src/locales/common/en.json
@@ -14,6 +14,8 @@
     "logout":"Log out",
     "newAccount":"Create a new account",
     "login":"Log in",
+    "closeMenu": "Close menu",
+    "openMenu": "Open menu",
     "mailingListTitle":"Remind me when the course starts",
     "subscribe":"subscribe",
     "tableOfContents":"Table of contents",

--- a/src/locales/common/fi.json
+++ b/src/locales/common/fi.json
@@ -14,6 +14,8 @@
     "logout":"Kirjaudu ulos",
     "newAccount":"Luo uusi tunnus",
     "login":"Kirjaudu sisään",
+    "closeMenu": "Sulje valikko",
+    "openMenu": "Avaa valikko",
     "mailingListTitle":"Muistuta minua kun kurssi alkaa",
     "subscribe":"tilaa",
     "tableOfContents":"Sisällysluettelo",


### PR DESCRIPTION
The sidebar menu button labels were hardcoded in Finnish.

<img width="688" height="394" alt="image" src="https://github.com/user-attachments/assets/98548f0f-81ff-4808-817a-6cfff91516d4" />

This PR localizes both labels for the English and Finnish locales using the existing `react-i18next` setup.

<img width="688" height="394" alt="image" src="https://github.com/user-attachments/assets/ca236586-cc67-4e40-848d-504e61b10475" />
