### PR TITLE
Add anchor link to programming exercise cards

### DIFF
--- a/src/partials/ProgrammingExercise/ProgrammingExerciseCard.js
+++ b/src/partials/ProgrammingExercise/ProgrammingExerciseCard.js
@@ -3,7 +3,11 @@ import styled from "styled-components"
 import ContentLoader from "react-content-loader"
 import { withTranslation } from "react-i18next"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
-import { faPencilAlt as icon, faRedo } from "@fortawesome/free-solid-svg-icons"
+import {
+  faPencilAlt as icon,
+  faRedo,
+  faLink,
+} from "@fortawesome/free-solid-svg-icons"
 import { Card, CardContent, Button, Typography } from "@material-ui/core"
 
 import { normalizeExerciseId } from "../../util/strings"
@@ -109,6 +113,27 @@ const StyledRefreshIcon = styled(FontAwesomeIcon)`
   color: white;
 `
 
+const Permalink = styled.a`
+  color: inherit;
+  display: inline-block;
+  margin-left: 0.5rem;
+  font-size: 0.5em;
+  text-decoration: none;
+  vertical-align: middle;
+  opacity: 0;
+
+  h3:hover &,
+  h3:focus-within &,
+  &:focus {
+    opacity: 1;
+  }
+
+  &:hover,
+  &:focus {
+    color: inherit;
+  }
+`
+
 class ProgrammingExerciseCard extends React.Component {
   render() {
     const {
@@ -122,15 +147,23 @@ class ProgrammingExerciseCard extends React.Component {
       difficulty,
     } = this.props
 
+    const exerciseId = normalizeExerciseId(`programming-exercise-${name}`)
+
     return (
-      <ProgrammingExerciseWrapper
-        id={normalizeExerciseId(`programming-exercise-${name}`)}
-      >
+      <ProgrammingExerciseWrapper id={exerciseId}>
         <Header completed={completed}>
           <StyledIcon icon={icon} size="2x" />
           <HeaderTitleContainer>
             <HeaderMuted>{this.props.t("programmingExercise")} </HeaderMuted>
-            <h3>{name}</h3>
+            <h3>
+              {name}
+              <Permalink
+                href={`#${exerciseId}`}
+                aria-label={`${name} permalink`}
+              >
+                <FontAwesomeIcon icon={faLink} aria-hidden="true" />
+              </Permalink>
+            </h3>
             {/*Ikävän kompleksinen. Onko syytä laittaa omaan komponenttiin?*/}
             {difficulty ? (
               <Difficulty>


### PR DESCRIPTION
When referencing an exercise assignment, for example for support purposes, a permalink to the exercise could previously only be obtained from the [list of exercises for a specific course part](https://programming-26.mooc.fi/part-3), or from the [list of all course exercises](https://programming-26.mooc.fi/all-exercises). It was not possible to get the permalink directly while viewing the exercise itself.

This update adds a permalink handle next to the exercise title, allowing users to copy or access the exercise URL directly from the exercise content. This works in the same way as permalinks for content chapters.

Tested in Chrome-based browsers and Firefox.

A screenshot showing the permalinks in their active state (by default, the links are hidden):

<img width="869" height="893" alt="image" src="https://github.com/user-attachments/assets/053632e6-9755-42eb-a7f0-2eb529da40f4" />
